### PR TITLE
Add Sacramento, CA

### DIFF
--- a/USlocalopendataportals.csv
+++ b/USlocalopendataportals.csv
@@ -114,6 +114,7 @@ Redmond,WA,26646,Government,No,https://data.redmond.gov,US City or County
 Rhode Island,RI,1051302,Government,No,http://www.ri.gov/data/,US State
 Rhode Island,RI,1051302,Government,No,http://www.transparency.ri.gov,US State
 Rockford,IL,152222,Government,No,https://data.illinois.gov/rockford,US City or County
+Sacramento,CA,472178,Government,Yes,http://portal.cityofsacramento.org/opendata,US City or County
 Salt Lake City,UT,186443,Government,No,https://data.slcgov.com,US City or County
 San Diego,CA,1307402,Community,in progress,http://catalog.opensandiego.org/,US City or County
 San Francisco,CA,797983,Government,Yes,http://data.sfgov.org,US City or County


### PR DESCRIPTION
Used [this](http://portal.cityofsacramento.org/opendata) page instead of [this](http://data.cityofsacramento.org/home/) page, as former has link to open data policy.
