### PR TITLE
Add Chattanooga data portal

### DIFF
--- a/USlocalopendataportals.csv
+++ b/USlocalopendataportals.csv
@@ -17,6 +17,7 @@ California,CA,37691912,Government,No,http://data.ca.gov/,US State
 Cambridge GIS,MA,105162,Government,in progress,http://cambridgegis.github.io/gisdata.html,US City or County
 Champaign,IL,39795,Government,No,https://data.illinois.gov/champaign,US City or County
 Charleston,SC,125583,Government,No,http://gis.charleston-sc.gov/dataportal/,US City or County
+Chattanooga,TN,170136,Government,Yes,http://data.chattlibrary.org,US City or County
 Chicago,IL,2707120,Government,Yes,https://data.cityofchicago.org,US City or County  
 Chicago [Metro],IL,9729825,Government,Yes,https://www.metrochicagodata.org,US City or County
 Cincinnati,OH,296223,Community,No,http://www.opendatacincy.org/,US City or County


### PR DESCRIPTION
Noticed that the column said 2011 census population. Population estimate taken from https://www.census.gov/popest/data/cities/totals/2011/SUB-EST2011-3.html
