### PR TITLE
Update the Policy URL for San Diego

### DIFF
--- a/USlocalpolicylocations.geoJSON
+++ b/USlocalpolicylocations.geoJSON
@@ -77679,7 +77679,7 @@
       "properties": {
         "Date": "12/16/2014",
         "Legal Means": "Legislation",
-        "Policy URL": "http://www.sandiego.gov/pad/pdf/opendatapolicy.pdf",
+        "Policy URL": "http://docs.sandiego.gov/council_reso_ordinance/rao2014/R-309441.pdf",
         "State": "CA",
         "City": "San Diego",
         "State Name": "California",


### PR DESCRIPTION
I noticed that the Policy URL for San Diego's Open Data Policy was out of date. 

This simple change corrects that and points to the current open data policy for the City of San Diego. 