### PR TITLE
Create a markdown version of San Diego's policy

### DIFF
--- a/open data policies in markdown/2015-City-of-San-Diego.md
+++ b/open data policies in markdown/2015-City-of-San-Diego.md
@@ -1,0 +1,104 @@
+# City of San Diego Open Data Policy
+
+**EFFECTIVE DATE: January 1, 2015**
+
+## BACKGROUND:
+
+The City of San Diego is committed to the principles of open, accessible, efficient, and transparent government, and the use of technology to help put those principles into practice. On December 17, 2013, the San Diego City Council approved San Diego Resolution R-308684 (Jan. 2, 2014) in support of creating an open data policy.
+
+## PURPOSE:
+
+This policy creates a process for making City data available online using open standards. The City will devote its best efforts to making its data publicly available online, while recognizing that it has numerous data sets and limited resources to dedicate to a new open data program. The City recognizes that making data available online in this manner will promote civic engagement, improve service delivery, allow for more effective communication with the public, and increase opportunities for economic development. This Policy is also intended to make the operation of City government more transparent, effective, and accountable to the public, and to allow the public to assist in identifying efficient solutions for government.
+
+## POLICY:
+
+### Section 1. Definitions:
+
+As used in this Policy:
+
+  **1.1** -- *Chief Data Officer* means an individual designated by the Mayor to oversee implementation of this Policy.
+
+  **1.2** -- *City Department* shall mean every mayoral and independent City Department and each City Council District.
+
+  **1.3** -- *Compliance Plan* means the document prepared by the Chief Data Officer under Section 2.5 of this Policy.
+
+  **1.4** -- *Data or Data Set* means statistical or factual information in digital form which: (a) is reflected in a list, table, graph, chart, map, or database that can be digitally transmitted or processed; and (b) is regularly created or maintained and controlled by the City and is a “record” as defined in San Diego Municipal Code section 22.2602. This Policy does not prohibit the City from voluntarily disclosing information not otherwise defined as “Data Set” or “Data” in this subdivision, nor does it prohibit the City from making voluntarily disclosed information accessible through the single Web Portal described in Section 2 of this Policy.
+
+  **1.5** -- *Effective Date* means the later of the date upon which the Resolution authorizing this policy takes effect in accordance with the City Charter, or January 1, 2015.
+
+  **1.6** --  *Implementation Plan* means the plan prepared by the Mayor or his designee and administered by the Chief Data Officer for implementation of this Policy.
+
+  **1.7** -- *IT Department* means the City Department responsible for information technology and whose responsibilities are described in San Diego Municipal Code sections 22.1601 through 22.1602.
+
+  **1.8** -- *Public Data Set* means, except as otherwise provided herein, a Data Set that is available for inspection by the public in accordance with any provision of law and is maintained on a computer system by, or on behalf of, a City Department. Public Data Set does not include:
+
+  a. any portion of a data set to which the City may deny access under applicable federal, state or local law, rule or regulation;
+
+  b. any data set that contains a significant amount of data to which the City may deny access under any other provision of a federal or state law, rule or regulation, or local law and where removing the data would impose undue financial or administrative burden;
+
+  c. data that reflects the internal deliberative process of the City, including negotiating positions, future procurements, or pending or reasonably anticipated legal or administrative proceedings;
+
+  d. data stored solely on a City-owned personal computing device, or data stored on a portion of a network that has been exclusively assigned to a single City employee or a single City-owned or -controlled computing device;
+
+  e. materials subject to copyright, patent, trademark, confidentiality agreements, or trade secret protection;
+
+  f. proprietary applications, computer code, software, operating systems, or similar materials;
+
+  g. employment records and internal employee-related directories; and
+
+  h. archival or historical material that is not digitized and would need to be converted to a digital, machine readable format.
+
+  **1.9** -- *Voluntary Compliance Standards* shall have the meaning described in Office of Management and Budget (OMB) Circular A-119 Revised, as modified from time to time, which currently includes standards developed or adopted by domestic and international organizations, including provisions that require owners of relevant intellectual property to agree to make that intellectual property available on a non-discriminatory, royalty-free or reasonable royalty basis to all interested parties.
+
+  **1.10** -- *Web Portal* means a collection of web services, accessible from a single web site, which brings information together from diverse sources in a uniform way.
+
+### Section 2. Chief Data Officer: Role, Responsibilities and Timeline for Actions:
+
+  **2.1** -- The Chief Data Officer, or other Mayoral designee, shall provide written guidelines describing how to prepare an inventory of Data Sets owned or managed by the City which is subject to this Policy and will publish the guidelines on the City’s web site in accordance with the Implementation Plan.
+
+  **2.2** -- The Chief Data Officer, or other Mayoral designee, shall publish the initial City Department inventories of Public Data Sets on the City’s web site.
+
+  **2.3** -- The Chief Data Officer shall prepare and publish technical guidelines for the publishing of Public Data Sets through a Web Portal, to make Public Data Sets available to the greatest number of users and for the greatest number of applications and shall, whenever practicable, use Voluntary Compliance Standards for web publishing and e-government, unless the Chief Data officer deems no Voluntary Compliance Standards are suitable. If the Chief Data Officer determines that Voluntary Compliance Standards are not suitable, then the Chief Data Officer shall identify the reasons why they are not suitable. The technical guidelines shall require a web application programming interface that permits application programs to request and receive Public Data Sets directly from the Web Portal. The technical guidelines shall be reviewed annually and updated as necessary by the Chief Data Officer.
+
+  **2.4** -- No later than 180 days from the Effective Date of this Policy, the Chief Data Officer shall submit a written report to the Mayor and the Council on the status of implementation of this Policy and publish the report on the City web site.
+
+  **2.5** -- No later than 18 months from the Effective Date of this Policy, and annually thereafter, the Chief Data Officer shall provide a Compliance Plan to the Mayor and the Council and publish the Compliance Plan on the City web site. City Departments shall cooperate with the Chief Data Officer in its preparation of the Compliance Plan. The Compliance Plan shall include:
+
+  a. a data inventory and a summary description of Public Data Sets under the control of each City Department;
+
+  b. a timeline for publication to the Web Portal of high value existing Public Data Sets, as determined by the Chief Data Officer after soliciting public input, with all high value Public Data Sets being published within five years of the Effective Date of this Policy; and
+
+  c. for any high value Public Data Set that cannot be made available on the Web Portal within the specified time, a statement of the reasons why the high value Public Data Set cannot be made available and, to the extent practicable, the date by which the City Department believes that it will be available on the Web Portal.
+
+  **2.6** -- The annual updates to the Compliance Plan shall include the specific measures undertaken to make additional Public Data Sets available on the Web Portal since the immediately preceding update, specific measures that will be undertaken prior to the next update, an update to the inventory of Public Data Sets, and, if necessary, any changes to the prioritization of Public Data Sets and an update to the timeline for the inclusion of Public Data Sets on the Web Portal. If a Public Data Set cannot be made available on the Web Portal on or before the Compliance Plan update, the update shall state the reasons it cannot and, to the extent practicable, the date by which the City believes the Public Data Set will be available on the Web Portal.
+
+  **2.7** -- The Chief Data Officer shall ensure that an appropriate disclaimer and terms of use are placed on the City web site which shall include, but not be limited to, the following: (a) Public Data Sets are provided for informational purposes only; (b) the City does not warranty the completeness, accuracy, content, or fitness for any particular purpose or use of any Public Data Set made available on the Web Portal, nor are any such warranties to be implied or inferred with respect to the Public Data Sets furnished therein; and (c) the City is not liable for any deficiencies in the completeness, accuracy, content, or fitness for any particular purpose or use of any Public Data Set, or application utilizing such data set. This open data policy shall not be construed to create a private right of action to enforce its provisions, and failure to comply with this policy shall not result in liability to the City. For purposes of clarity, nothing in Section 2.7 prevents Public Data Sets from being used for any lawful purpose, including use of the Public Data Sets to develop commercial applications.
+
+  **2.8** -- The Chief Data Officer shall review this Policy within one year of its Effective Date and annually thereafter and propose amendments or revisions as needed.
+
+### Section 3. City Departments: Roles, Responsibilities:
+
+  **3.1** -- All City Departments shall provide to the Chief Data Officer an inventory of Data Sets that they own or manage, consistent with the Implementation Plan.
+
+  **3.2** --  Within 18 months of the Effective Date of this Policy, the City will begin publishing to the Web Portal high value Public Data Sets, in accordance with the publication schedule set forth in the Compliance Plan.
+
+  **3.3** -- City Departments shall make Public Data Sets available in accordance with technical guidelines in the form of a process narrative published by the Chief Data Officer and in a Voluntary Compliance Standard format that permits automated processing and shall make use of appropriate technology to notify the public of all updates.
+
+  **3.4** -- City Departments shall update Data Sets as close as possible to the time of data collection to preserve the integrity and usefulness of the data sets, as determined by the City Department.
+
+  **3.5** -- Public Data Sets shall be made available without any registration requirement, license requirement, or restrictions on their lawful use. Registration requirements, license requirements, or restrictions as used in this section shall not include measures required to ensure access to Public Data Sets, to protect the Web Portal housing Public Data Sets from unlawful abuse, or attempts to damage or impair use of the web site, or to analyze the types of data being used to improve service delivery.
+
+  **3.6** -- To the greatest extent possible, Public Data Sets shall be accessible to external search capabilities using open and commonly used standards and formats as described in the technical guidelines.
+
+### Section 4.
+
+  **4.0** -- Nothing in this policy is intended to modify the City’s record retention policies or
+requirements.
+
+  **4.1** --  Nothing in this policy is intended to preclude the City from entering into agreements with other agencies for the provision of their data through the City’s Web Portal.
+
+## HISTORY:
+
+‟Open Data Program”
+
+Adopted by Resolution R-______ - xx/xx/2014


### PR DESCRIPTION
I noticed that the City of San Diego's Open Data Policy was linked to in the GeoJSON file, but the policy itself had not been converted to markdown and added to the repository.

This Pull Request both creates that file and adds some light markdown formatting. Style and formatting edits are welcome.